### PR TITLE
no tag on release link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 cadquery-freecad-module
 =======================
-[![GitHub version](https://badge.fury.io/gh/jmwright%2Fcadquery-freecad-module.svg)](https://github.com/jmwright/cadquery-freecad-module/releases/tag/v0.3.0)
+[![GitHub version](https://badge.fury.io/gh/jmwright%2Fcadquery-freecad-module.svg)](https://github.com/jmwright/cadquery-freecad-module/releases)
 [![License](https://img.shields.io/badge/license-LGPL-lightgrey.svg)](https://github.com/jmwright/cadquery-freecad-module/blob/master/LICENSE)
 
 A module-workbench combo that adds a CadQuery editor to FreeCAD. Please see the [wiki](https://github.com/jmwright/cadquery-freecad-module/wiki) for more detailed information on getting started.
@@ -10,7 +10,7 @@ A module-workbench combo that adds a CadQuery editor to FreeCAD. Please see the 
 ## Installation
 **Requires FreeCAD 0.14 or newer**
 
-Download the [latest released version](https://github.com/jmwright/cadquery-freecad-module/releases/tag/v0.3.0), extract the archive file, and copy the `CadQuery` directory to FreeCAD's `Mod` directory on your system. The module is implemented completely in Python so it should just work the next time you start FreeCAD. Some typical `Mod` directory locations are as follows.
+Download the [latest released version](https://github.com/jmwright/cadquery-freecad-module/releases), extract the archive file, and copy the `CadQuery` directory to FreeCAD's `Mod` directory on your system. The module is implemented completely in Python so it should just work the next time you start FreeCAD. Some typical `Mod` directory locations are as follows.
 
 ### Linux
 * /usr/lib/freecad/Mod


### PR DESCRIPTION
the release badge and link pointed to older v0.3.0. 
No tag so it always points to the list of releases with the last one on top