### PR TITLE
changed __name__ to be more descriptive

### DIFF
--- a/CQGui/Command.py
+++ b/CQGui/Command.py
@@ -229,7 +229,7 @@ class CadQueryExecuteScript:
 
             # We import this way because using execfile() causes non-standard script execution in some situations
             with revert_sys_modules():
-                imp.load_source('temp_module', tempFile.name)
+                imp.load_source('__cq_freecad_module__', tempFile.name)
 
         msg = QtGui.QApplication.translate(
             "cqCodeWidget",

--- a/Libs/cadquery/cadquery/cqgi.py
+++ b/Libs/cadquery/cadquery/cqgi.py
@@ -101,6 +101,7 @@ class CQModel(object):
             self.set_param_values(build_parameters)
             collector = ScriptCallback()
             env = EnvironmentBuilder().with_real_builtins().with_cadquery_objects() \
+                .add_entry("__name__", "__cqgi__") \
                 .add_entry("show_object", collector.show_object) \
                 .add_entry("debug", collector.debug) \
                 .add_entry("describe_parameter",collector.describe_parameter) \


### PR DESCRIPTION
At this time the value of `__name__` in the base script being run within FreeCAD is:
- cqgi: `__builtins__`
- non-cqgi: `temp_module`

This update changes this value to:
- cqgi: `__cqgi__`
- non-cqgi: `__cq_freecad_module__`

What do you think? I'm open to suggestions if you don't like that naming :smile: 
