### PR TITLE
Misc. typos

### DIFF
--- a/CQGui/Command.py
+++ b/CQGui/Command.py
@@ -38,7 +38,7 @@ def revert_sys_modules():
     try:
         yield
     finally:
-        # irrespective of the succes of the context's execution, new modules
+        # irrespective of the success of the context's execution, new modules
         # will be deleted upon exit
         for mod_name in list(sys.modules.keys()):
             if mod_name not in modules_before:

--- a/changes.md
+++ b/changes.md
@@ -42,7 +42,7 @@ v0.3.0
     * Converted thickness setting to thickness boolean in the Lego brick example (thanks @galou) #59
     * Improved parametric encosure (Ex023) example (thanks @galou) #61
     * Added braille and NumPy examples (thanks @galou) #61
-    * Embedded CadQuery libarary as a git subtree to lessen maintainance issues
+    * Embedded CadQuery libarary as a git subtree to lessen maintenance issues
     * Embedded Pint library for units handling
     * Fixed version number in InitGui.py
     * Added BoundingBox centerOption example (Ex030) (thanks @huskier) #66

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -78,7 +78,7 @@ print(file.read())
 
 ### Using an External Code Editor
 
-Oftentimes, users prefer another code editor or IDE over the one that is built in to this workbench. In order to use an external editor, set `use_external_editor` to `True` in `Settings.py`. A restart of FreeCAD will most likely be required to make this change take effect. With this option enabled, a script can be opened in the workbench's internal code editor initially, and then edited from there on witin an external editor. The internal editor will update automatically and the 3D view will automatically be refreshed when the script changes.
+Oftentimes, users prefer another code editor or IDE over the one that is built in to this workbench. In order to use an external editor, set `use_external_editor` to `True` in `Settings.py`. A restart of FreeCAD will most likely be required to make this change take effect. With this option enabled, a script can be opened in the workbench's internal code editor initially, and then edited from there on within an external editor. The internal editor will update automatically and the 3D view will automatically be refreshed when the script changes.
 
 If you are using an external editor that supports type annotations, the [cadqury_stubs](https://github.com/Grawp/cadquery_stubs) can be helpful. This helps with things like auto-completion and argument type hinting.
 


### PR DESCRIPTION
Found using `codespell -q 3 --skip="./ThirdParty,./Libs"`