### PR TITLE
Update cadquery-ocp installation to cadquery-ocp-novtk and latest version for build123d compat

### DIFF
--- a/freecad/CadQuery/Command.py
+++ b/freecad/CadQuery/Command.py
@@ -75,7 +75,7 @@ class Build123DInstall:
         import subprocess
         print("Starting to install Build123d...")
         subprocess.run(["python", "-m", "pip", "install", "--upgrade", "build123d"], capture_output=False)
-        subprocess.run(["python", "-m", "pip", "install", "--upgrade", "cadquery-ocp==7.8.1.1.post1"], capture_output=False)
+        subprocess.run(["python", "-m", "pip", "install", "--upgrade", "cadquery-ocp-novtk==7.9.3.1.1"], capture_output=False)
         print("Build123d has been installed! Please restart FreeCAD.")
 
 


### PR DESCRIPTION
- latest release of build123d==0.11.1 now depends on cadquery-ocp-novtk 7.9.x. This PR updates this, and likely fixes currently broken behavior of installs with incompatible cadquery-ocp 7.8.x